### PR TITLE
Fix composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.0",
         "symfony/framework-bundle": ">=2.1.0",
-        "symfony/property-access": "~2.5",
+        "symfony/property-access": ">=2.2.0",
         "sybio/image-workshop": "2.0.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
Allow project with symfony/framework-bundle < 2.5 to install the bundle.
