### PR TITLE
Throw exception when try to use a format that doesn't registered

### DIFF
--- a/Manager/BaseEntityWithImageManager.php
+++ b/Manager/BaseEntityWithImageManager.php
@@ -78,6 +78,10 @@ class BaseEntityWithImageManager extends BaseEntityWithFileManager
      */
     private function transformPathWithFormat($path, $format)
     {
+        if (!array_key_exists($format, $this->imageFormatDefinition)) {
+            throw new \InvalidArgumentException("Unknow format : the format [$format] isn't registered");
+        }
+
         return str_replace('{-imgformat-}', $format, $path);
     }
 


### PR DESCRIPTION
Currently, if a developer try to access to an image with a format that doesn't exists, there is no feedback and the image will never display.

I purpose to throw an exception if developer try to use an image format that doesn't exist.
