### PR TITLE
Fix removing file when replaceFile method is used

### DIFF
--- a/Manager/BaseEntityWithImageManager.php
+++ b/Manager/BaseEntityWithImageManager.php
@@ -271,11 +271,10 @@ class BaseEntityWithImageManager extends BaseEntityWithFileManager
      * @param string             $propertyName   The property linked to the file
      * @param string             $sourceFilepath The image source folder
      * @param string|null        $destFilepath   The image destination folder
-     * @param string             $operation      'copy' or 'rename'
      *
      * @return array|null An array containing informations about the copied file
      */
-    public function replaceFile(BaseEntityWithFile $entity, $propertyName, $sourceFilepath, $destFilepath = null, $operation = 'copy')
+    public function replaceFile(BaseEntityWithFile $entity, $propertyName, $sourceFilepath, $destFilepath = null)
     {
         $propertyGetter = $this->getter($propertyName);
         $propertyFileNameGetter = $this->getter($propertyName, true);

--- a/Resources/doc/reference-BaseEntityWithImageManager.md
+++ b/Resources/doc/reference-BaseEntityWithImageManager.md
@@ -102,7 +102,6 @@ Replace a property file by another, giver it&#039;s path
     - `$propertyName` (`string`) &mdash; The property linked to the file
     - `$sourceFilepath` (`string`) &mdash; The image source folder
     - `$destFilepath` (`string`|`null`) &mdash; The image destination folder
-    - `$operation` (`string`) &mdash; &#039;copy&#039; or &#039;rename&#039;
 - _Returns:_ An array containing informations about the copied file
     - `array`
     - `null`


### PR DESCRIPTION
In the `BaseEntityWithImageManager::replaceFile` when we retrieve `$oldDestPath`, the file can't be remove because the entity was update with the new file path.

So filesystem can keep a lot of unused files.
