### PR TITLE
Travis configuration optimisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
 before_script:
   - composer selfupdate
-  - composer require symfony/framework-bundle:${SYMFONY_VERSION} --no-update
+  - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
   - composer update --dev
 
 script:


### PR DESCRIPTION
Change Travis configuration to force all Symfony deps to be set in specific version and not only one component.