### PR TITLE
Allow to set custom web_directory path in ImageType

### DIFF
--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -45,11 +45,12 @@ class ImageType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setOptional(['format', 'update_cache', 'preview']);
+        $resolver->setOptional(['format', 'update_cache', 'preview', 'web_directory']);
         $resolver->setDefaults([
-            'format'       => 'thumbnail',
-            'update_cache' => true,
-            'preview'      => true
+            'format'        => 'thumbnail',
+            'update_cache'  => true,
+            'preview'       => true,
+            'web_directory' => $this->webDirectory
         ]);
     }
 
@@ -88,7 +89,7 @@ class ImageType extends AbstractType
             $imagePath .= sprintf('?v=%d', $this->generateTimestamp($accessor, $parentData));
         }
 
-        return str_replace('{-imgformat-}', $options['format'], $this->webDirectory.$imagePath);
+        return str_replace('{-imgformat-}', $options['format'], $options['web_directory'].$imagePath);
     }
 
     /**

--- a/Form/Type/ImageType.php
+++ b/Form/Type/ImageType.php
@@ -7,71 +7,104 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class ImageType extends AbstractType
 {
+    /** @var string */
     private $webDirectory;
 
+    /**
+     * Constructor
+     *
+     * @param string $webDirectory
+     */
     public function __construct($webDirectory)
     {
         $this->webDirectory = $webDirectory;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
         return 'file';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'image';
     }
 
     /**
-     * Add the image_path option
-     *
-     * @param OptionsResolverInterface $resolver
+     * {@inheritdoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setOptional(array('format', 'update_cache', 'preview'));
-        $resolver->setDefaults(array(
+        $resolver->setOptional(['format', 'update_cache', 'preview']);
+        $resolver->setDefaults([
             'format'       => 'thumbnail',
             'update_cache' => true,
             'preview'      => true
-            ));
+        ]);
     }
 
     /**
-     * Pass the image URL to the view
-     *
-     * @param FormView $view
-     * @param FormInterface $form
-     * @param array $options
+     * {@inheritdoc}
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        $view->vars['preview'] = $options['preview'];
-
+        $view->vars['preview']   = $options['preview'];
         $view->vars['image_url'] = null;
+
         if ($view->vars['preview']) {
-            $accessor = PropertyAccess::createPropertyAccessor();
-
-            $property = $form->getName().'Filename';
-            $parentData = $form->getParent()->getData();
-            $imagePath = $accessor->getValue($parentData, $property);
-
-            if ($options['update_cache'] === true) {
-                $imagePath .= sprintf('?v=%d',
-                    $accessor->isReadable($parentData, 'updatedAt') && $accessor->getValue($parentData, 'updatedAt') instanceof \DateTime ?
-                        $accessor->getValue($parentData, 'updatedAt')->format('U') :
-                        date('U')
-                );
-            }
-
-            $view->vars['image_url'] = $imagePath ?
-                str_replace('{-imgformat-}', $options['format'], $this->webDirectory.$imagePath) : null;
+            $view->vars['image_url'] = $this->getImagePath($form, $options);
         }
+    }
+
+    /**
+     * Build image path
+     *
+     * @param FormInterface $form
+     * @param array         $options
+     * @return string
+     */
+    private function getImagePath(FormInterface $form, array $options)
+    {
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        $property = $form->getName().'Filename';
+        $parentData = $form->getParent()->getData();
+        $imagePath = $accessor->getValue($parentData, $property);
+        if (empty($imagePath)) {
+            return null;
+        }
+
+        if (true === $options['update_cache']) {
+            $imagePath .= sprintf('?v=%d', $this->generateTimestamp($accessor, $parentData));
+        }
+
+        return str_replace('{-imgformat-}', $options['format'], $this->webDirectory.$imagePath);
+    }
+
+    /**
+     * Generate timestamp data used for cache management
+     *
+     * @param PropertyAccessorInterface $accessor
+     * @param mixed                     $parentData
+     * @return int
+     */
+    private function generateTimestamp(PropertyAccessorInterface $accessor, $parentData)
+    {
+        if ($accessor->isReadable($parentData, 'updatedAt') && $accessor->getValue($parentData, 'updatedAt') instanceof \DateTime) {
+            return $accessor->getValue($parentData, 'updatedAt')->format('U');
+        }
+
+        return date('U');
     }
 }
 

--- a/Resources/doc/05-image-form-field.md
+++ b/Resources/doc/05-image-form-field.md
@@ -32,7 +32,8 @@ It adds several new options :
  + **preview** (Default ```true```) : Hide the image display if set to false ;
  + **format** (Default ```'thumbnail'```) : The image format (must be existing for this property) ;
  + **update_cache** (Default ```true```) : Adds a version timestamp to the file name in HTML output.
-
+ + **web_directory** (Default _novaway.fmb.webdir_ parameter value) : Web directory path
+ 
  Here is an example of how to use these options:
  ``` php
  $builder

--- a/Tests/Units/Form/Type/ImageType.php
+++ b/Tests/Units/Form/Type/ImageType.php
@@ -26,15 +26,15 @@ class ImageType extends BaseManagerTestCase{
             )
             ->mock($resolver)
                 ->call('setOptional')
-                    ->withArguments(array('format', 'update_cache', 'preview'))
+                    ->withArguments(['format', 'update_cache', 'preview', 'web_directory'])
                     ->once()
                 ->call('setDefaults')
-                    ->withArguments(
-                        array(
-                            'format'       => 'thumbnail',
-                            'update_cache' => true,
-                            'preview'      => true
-                        ))
+                    ->withArguments([
+                        'format'        => 'thumbnail',
+                        'update_cache'  => true,
+                        'preview'       => true,
+                        'web_directory' => '/mydir/',
+                    ])
                     ->once()
         ;
     }
@@ -47,7 +47,7 @@ class ImageType extends BaseManagerTestCase{
         $this
             ->if(
                 $testedClass = $this->createTestedClassInstance(),
-                $testedClass->buildView($view, $form, array('preview' => false))
+                $testedClass->buildView($view, $form, ['preview' => false])
             )
             ->array($view->vars)
                 ->hasKey('image_url')
@@ -74,12 +74,13 @@ class ImageType extends BaseManagerTestCase{
 
         $this
             ->if(
-                $testedClass = $this->createTestedClassInstance(),
-                $testedClass->buildView($view, $form, array(
-                    'preview'      => true,
-                    'format'       => $format,
-                    'update_cache' => $updateCache
-                ))
+                $testedClass = $this->createTestedClassInstance('/path/'),
+                $testedClass->buildView($view, $form, [
+                    'preview'       => true,
+                    'format'        => $format,
+                    'update_cache'  => $updateCache,
+                    'web_directory' => '/mydir/',
+                ])
             )
             ->array($view->vars)
                 ->hasKey('image_url')


### PR DESCRIPTION
ImageType use a global configuration for "web directory".

It doesn't allow to set different directory for different fields.

This PR add a "web_directory" option to ImageType to override global configuration.