### PR TITLE
Service configuration cleaning

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,14 +1,9 @@
 parameters:
-    novaway.fmb.controller.class: Novaway\Bundle\FileManagementBundle\Controller\Controller
     novaway.fmb.twigextension.class: Novaway\Bundle\FileManagementBundle\Twig\Extension\FileManagementExtension
     novaway.fmb.form.type.image.extension.class: Novaway\Bundle\FileManagementBundle\Form\Extensions\ImageTypeExtension
     novaway.fmb.form.type.image.class: Novaway\Bundle\FileManagementBundle\Form\Type\ImageType
 
 services:
-    novaway.fmb.controller:
-        class: %novaway.fmb.controller.class%
-        arguments: [@service_container]
-
     novaway.fmb.form.type.image:
         class: %novaway.fmb.form.type.image.class%
         arguments: [%novaway.fmb.webdir%]

--- a/Resources/doc/05-image-form-field.md
+++ b/Resources/doc/05-image-form-field.md
@@ -32,7 +32,7 @@ It adds several new options :
  + **preview** (Default ```true```) : Hide the image display if set to false ;
  + **format** (Default ```'thumbnail'```) : The image format (must be existing for this property) ;
  + **update_cache** (Default ```true```) : Adds a version timestamp to the file name in HTML output.
- + **web_directory** (Default _novaway.fmb.webdir_ parameter value) : Web directory path
+ + **web_directory** (Default _novaway_file_management.web_file_path_ parameter value or '/' if the parameter isn't define) : Web directory path
  
  Here is an example of how to use these options:
  ``` php


### PR DESCRIPTION
This PR was initialy open for issue #45 

When exploring code, I realize that `novaway.fmb.webdir` parameter inherits from `novaway_file_management.web_file_path` configuration.

So I juste clean the `services.yml` configuration file by deleting non exists Controller service.