### PR TITLE
Manager initialization detection

### DIFF
--- a/Manager/Traits/FileManagerTrait.php
+++ b/Manager/Traits/FileManagerTrait.php
@@ -39,7 +39,7 @@ trait FileManagerTrait
      * @param array $arrayFilepath Associative array containing the file path for each property of the managed entity.
      *                             This array must also contain a 'root' and a 'web' path.
      */
-    protected function initialize($arrayFilepath)
+    protected function initialize(array $arrayFilepath)
     {
         if (!isset($arrayFilepath['bundle.web'])) {
             throw new \InvalidArgumentException('$arrayFilepath must have a bundle.web key (even empty).');

--- a/Manager/Traits/FileManagerTrait.php
+++ b/Manager/Traits/FileManagerTrait.php
@@ -27,6 +27,11 @@ trait FileManagerTrait
      */
     protected $webPath;
 
+    /**
+     * @var bool
+     */
+    private $booted = false;
+
 
     /**
      * Initialize trait properties
@@ -52,6 +57,8 @@ trait FileManagerTrait
             $this->rootPath  = $classDir.'/../../../../../../../web'.$this->webPath;
         }
         $this->arrayFilepath = $arrayFilepath;
+
+        $this->booted = true;
     }
 
     /**
@@ -65,6 +72,10 @@ trait FileManagerTrait
      */
     public function saveWithFiles(BaseEntityWithFile $entity, $callback = null)
     {
+        if (!$this->booted) {
+            throw new \Exception('Manager has not been initialized');
+        }
+
         $managedProperties = $this->arrayFilepath;
         $managedProperties = array_keys($managedProperties);
 
@@ -104,6 +115,10 @@ trait FileManagerTrait
      */
     public function deleteWithFiles(BaseEntityWithFile $entity)
     {
+        if (!$this->booted) {
+            throw new \Exception('Manager has not been initialized');
+        }
+
         $managedProperties = $this->arrayFilepath;
         $managedProperties = array_keys($managedProperties);
 

--- a/Manager/Traits/ImageManagerTrait.php
+++ b/Manager/Traits/ImageManagerTrait.php
@@ -37,7 +37,7 @@ trait ImageManagerTrait
      * @param array $imageFormatDefinition Associative array to define image properties which be stored on filesystem
      * @param array $imageFormatChoices    Associative array to apply some format definitions to an entity property
      */
-    protected function initialize($arrayFilepath, $imageFormatDefinition, $imageFormatChoices)
+    protected function initialize(array $arrayFilepath, $imageFormatDefinition, $imageFormatChoices)
     {
         $this->parentInitialize($arrayFilepath);
 


### PR DESCRIPTION
When a developer create a custom manager based on traits, he must be call `initialize` method.

This PR check for manager initialization and if not launch an exception.