### PR TITLE
Remove bundle.root path detection from traits

### DIFF
--- a/Manager/BaseEntityWithFileManager.php
+++ b/Manager/BaseEntityWithFileManager.php
@@ -31,6 +31,14 @@ class BaseEntityWithFileManager implements FileManagerInterface
      */
     public function __construct($arrayFilepath, $entityManager)
     {
+        if (empty($arrayFilepath['bundle.root'])) {
+            $bundleWeb = (isset($arrayFilepath['bundle.web'])) ? $arrayFilepath['bundle.web'] : '';
+
+            $reflexionObject = new \ReflectionObject($this);
+            $classDir        = dirname($reflexionObject->getFileName());
+            $arrayFilepath['bundle.root'] = $classDir.'/../../../../../../../web'.$bundleWeb;
+        }
+
         $this->initialize($arrayFilepath);
 
         $this->entityManager = $entityManager;

--- a/Manager/BaseEntityWithImageManager.php
+++ b/Manager/BaseEntityWithImageManager.php
@@ -34,6 +34,14 @@ class BaseEntityWithImageManager implements FileManagerInterface
      */
     public function __construct($arrayFilepath, $entityManager, $imageFormatDefinition, $imageFormatChoices)
     {
+        if (empty($arrayFilepath['bundle.root'])) {
+            $bundleWeb = (isset($arrayFilepath['bundle.web'])) ? $arrayFilepath['bundle.web'] : '';
+
+            $reflexionObject = new \ReflectionObject($this);
+            $classDir        = dirname($reflexionObject->getFileName());
+            $arrayFilepath['bundle.root'] = $classDir.'/../../../../../../../web'.$bundleWeb;
+        }
+
         $this->initialize($arrayFilepath, $imageFormatDefinition, $imageFormatChoices);
 
         $this->entityManager = $entityManager;

--- a/Manager/Traits/FileManagerTrait.php
+++ b/Manager/Traits/FileManagerTrait.php
@@ -45,19 +45,17 @@ trait FileManagerTrait
             throw new \InvalidArgumentException('$arrayFilepath must have a bundle.web key (even empty).');
         }
 
-        $this->webPath = $arrayFilepath['bundle.web'];
-
-        unset($arrayFilepath['bundle.web']);
-        if (isset($arrayFilepath['bundle.root']) && $arrayFilepath['bundle.root'] != null) {
-            $this->rootPath = $arrayFilepath['bundle.root'];
-            unset($arrayFilepath['bundle.root']);
-        } else {
-            $reflexionObject = new \ReflectionObject($this);
-            $classDir        = dirname($reflexionObject->getFileName());
-            $this->rootPath  = $classDir.'/../../../../../../../web'.$this->webPath;
+        if (empty($arrayFilepath['bundle.root'])) {
+            throw new \InvalidArgumentException('$arrayFilepath must have a bundle.root key.');
         }
-        $this->arrayFilepath = $arrayFilepath;
 
+        $this->webPath = $arrayFilepath['bundle.web'];
+        unset($arrayFilepath['bundle.web']);
+
+        $this->rootPath = $arrayFilepath['bundle.root'];
+        unset($arrayFilepath['bundle.root']);
+
+        $this->arrayFilepath = $arrayFilepath;
         $this->booted = true;
     }
 

--- a/Tests/Units/Manager/BaseEntityWithFileManager.php
+++ b/Tests/Units/Manager/BaseEntityWithFileManager.php
@@ -455,16 +455,12 @@ class BaseEntityWithFileManager extends BaseManagerTestCase
     {
         return array(
             array(
-                array('bundle.web' => '', 'userPhoto' => ''),
+                array('bundle.web' => '', 'bundle.root' => '/tmp/root', 'userPhoto' => ''),
                 array('userPhoto')
             ),
             array(
-                array('bundle.web' => '', 'bundle.root' => '', 'userPhoto' => ''),
-                array('bundle.root', 'userPhoto')
-            ),
-            array(
-                array('bundle.web' => '', 'bundle.root' => '', 'userPhoto' => '', 'userCertificate' => ''),
-                array('bundle.root', 'userPhoto', 'userCertificate')
+                array('bundle.web' => '', 'bundle.root' => '/tmp/root', 'userPhoto' => '', 'userCertificate' => ''),
+                array('userPhoto', 'userCertificate')
             ),
         );
     }


### PR DESCRIPTION
Because the dection doesn't work in the trait, it must be defined is the manager implementation.