### PR TITLE
Travis configuration optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.0
   - 5.6
   - 5.5
-  - 5.4
 
 env:
   - SYMFONY_VERSION=3.0.*@dev
@@ -16,6 +15,8 @@ env:
 matrix:
   allow_failures:
     - php: 7.0
+    - env: SYMFONY_VERSION=3.0.*@dev
+  fast_finish: true
 
 before_script:
   - composer selfupdate


### PR DESCRIPTION
* Remove test with PHP 5.4 (unsupported)
* Allow failure for Symfony 3

This PR can be merge as soon as tests will be green :)