### PR TITLE
Rename FileManagerTrait's replaceFile method in ImageManagerTrait

### DIFF
--- a/Manager/Traits/ImageManagerTrait.php
+++ b/Manager/Traits/ImageManagerTrait.php
@@ -13,6 +13,7 @@ trait ImageManagerTrait
         getFileAbsolutePath as private parentFileAbsolutePath;
         getFileWebPath as private parentGetFileWebPath;
         initialize as private parentInitialize;
+        replaceFile as private parentReplaceFile;
     }
 
     /**


### PR DESCRIPTION
To be able to call the replaceFile method from the FileManagerTrait when your manager already use the ImageManagerTrait